### PR TITLE
feat: install nodejs into nodejs-prefix, and make it configurable

### DIFF
--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -145,22 +145,22 @@ type Node struct {
 	npmRegistry string
 }
 
-func checkNode() (node *Node, err error) {
+func checkNode(nodePrefix string) (node *Node, err error) {
 	var installed bool
 CheckNodejs:
 	version, major, err := getNodejsVersion()
 	if err != nil || major < minNodejsVersion {
 		PATH := os.Getenv("PATH")
-		nodeBinDir := "/usr/local/nodejs/bin"
+		nodeBinDir := fmt.Sprintf("%s/bin", nodePrefix)
 		if !strings.Contains(PATH, nodeBinDir) {
 			os.Setenv("PATH", fmt.Sprintf("%s%c%s", nodeBinDir, os.PathListSeparator, PATH))
 			goto CheckNodejs
 		} else if !installed {
-			err = os.RemoveAll("/usr/local/nodejs")
+			err = os.RemoveAll(nodePrefix)
 			if err != nil {
 				return
 			}
-			err = installNodejs("/usr/local/nodejs", nodejsLatestLTS)
+			err = installNodejs(nodePrefix, nodejsLatestLTS)
 			if err != nil {
 				return
 			}

--- a/server/nodejs.go
+++ b/server/nodejs.go
@@ -151,7 +151,7 @@ CheckNodejs:
 	version, major, err := getNodejsVersion()
 	if err != nil || major < minNodejsVersion {
 		PATH := os.Getenv("PATH")
-		nodeBinDir := fmt.Sprintf("%s/bin", nodePrefix)
+		nodeBinDir := path.Join(nodePrefix, "bin")
 		if !strings.Contains(PATH, nodeBinDir) {
 			os.Setenv("PATH", fmt.Sprintf("%s%c%s", nodeBinDir, os.PathListSeparator, PATH))
 			goto CheckNodejs

--- a/server/server.go
+++ b/server/server.go
@@ -49,6 +49,7 @@ func Serve(efs *embed.FS) {
 		cdnDomainChina string
 		unpkgDomain    string
 		etcDir         string
+		nodejsPrefix   string
 		yarnCacheDir   string
 		logLevel       string
 		logDir         string
@@ -63,6 +64,7 @@ func Serve(efs *embed.FS) {
 	flag.StringVar(&cdnDomain, "cdn-domain", "", "cdn domain")
 	flag.StringVar(&cdnDomainChina, "cdn-domain-china", "", "cdn domain for china")
 	flag.StringVar(&unpkgDomain, "unpkg-domain", "", "proxy domain for unpkg.com")
+	flag.StringVar(&nodejsPrefix, "nodejs-prefix", "", "nodejs installation dir (default: [etc-dir]/nodejs)")
 	flag.StringVar(&etcDir, "etc-dir", "/usr/local/etc/esmd", "the etc dir to store data")
 	flag.StringVar(&yarnCacheDir, "yarn-cache-dir", "", "the cache dir for `yarn add`")
 	flag.StringVar(&logLevel, "log-level", "info", "log level")
@@ -101,7 +103,10 @@ func Serve(efs *embed.FS) {
 	}
 	log.SetLevelByName(logLevel)
 
-	node, err = checkNode()
+	if nodejsPrefix == "" {
+		nodejsPrefix = path.Join(etcDir, "nodejs")
+	}
+	node, err = checkNode(nodejsPrefix)
 	if err != nil {
 		log.Fatalf("check nodejs env: %v", err)
 	}


### PR DESCRIPTION
Because it's easier to manage permissions when everything that is supposed to be owned by the server process is in the same place. Because the nodejs installation doesn't have any clear requirement to be where it is, figured it could be moved to the etc dir.

Also embedded an npmrc to be picked up by the installed nodejs. There isn't any example to override the npmrc to be embedded during the build process, but that's exactly how I plan do to it.