### PR TITLE
bugfix: fix attempting to bind to invalid https port

### DIFF
--- a/server/server.go
+++ b/server/server.go
@@ -167,7 +167,7 @@ func Serve(efs *embed.FS) {
 		TLS: rex.TLSConfig{
 			Port: uint16(httpsPort),
 			AutoTLS: rex.AutoTLSConfig{
-				AcceptTOS: !isDev,
+				AcceptTOS: httpsPort > 0 && !isDev,
 				CacheDir:  path.Join(etcDir, "autotls"),
 			},
 		},


### PR DESCRIPTION
I'm not sure if there's something I'm doing wrong, but when I don't configure this (I do not want https support at all as we do our own TLS termination), it was still failing if the TLS config was passed in.