### PR TITLE
Cache lru and some utils

### DIFF
--- a/server/storage/cache.go
+++ b/server/storage/cache.go
@@ -10,7 +10,7 @@ import (
 )
 
 type Cache interface {
-	Has(key string) bool
+	Has(key string) (bool, error)
 	Get(key string) ([]byte, error)
 	Set(key string, value []byte, ttl time.Duration) error
 	Delete(key string) error

--- a/server/storage/cache.go
+++ b/server/storage/cache.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
 	"strings"
 	"time"
 
@@ -9,7 +10,7 @@ import (
 )
 
 type Cache interface {
-	Has(key string) (bool, error)
+	Has(key string) bool
 	Get(key string) ([]byte, error)
 	Set(key string, value []byte, ttl time.Duration) error
 	Delete(key string) error
@@ -25,28 +26,23 @@ func OpenCache(url string) (cache Cache, err error) {
 		return
 	}
 
-	path, query := utils.SplitByFirstByte(url, '?')
-	name, addr := utils.SplitByFirstByte(path, ':')
+	name, addr := utils.SplitByFirstByte(url, ':')
 	driver, ok := drivers[strings.ToLower(name)]
 	if !ok {
 		err = fmt.Errorf("Unknown driver '%s'", name)
 		return
 	}
-
-	args := map[string]string{}
-	for _, q := range strings.Split(query, "&") {
-		k, v := utils.SplitByFirstByte(q, '=')
-		if len(k) > 0 {
-			args[k] = v
-		}
+	path, options, err := parseConfigUrl(addr)
+	if err != nil {
+		return
 	}
 
-	cache, err = driver.Open(addr, args)
+	cache, err = driver.Open(path, options)
 	return
 }
 
 type CacheDriver interface {
-	Open(addr string, args map[string]string) (cache Cache, err error)
+	Open(addr string, args url.Values) (cache Cache, err error)
 }
 
 func RegisterCache(name string, driver CacheDriver) {

--- a/server/storage/cache_memory.go
+++ b/server/storage/cache_memory.go
@@ -24,17 +24,17 @@ type mCache struct {
 	gcTimer    *time.Timer
 }
 
-func (mc *mCache) Has(key string) bool {
+func (mc *mCache) Has(key string) (bool, error) {
 	mc.lock.RLock()
 	s, ok := mc.storage[key]
 	mc.lock.RUnlock()
 
 	if ok && s.isExpired() {
 		go mc.Delete(key)
-		ok = false
+		return false, nil
 	}
 
-	return ok
+	return ok, nil
 }
 
 func (mc *mCache) Get(key string) (value []byte, err error) {

--- a/server/storage/cache_memory_lru.go
+++ b/server/storage/cache_memory_lru.go
@@ -1,0 +1,63 @@
+package storage
+
+import (
+	"time"
+
+	"github.com/dgraph-io/ristretto"
+)
+
+type mLRUCache struct {
+	cache *ristretto.Cache
+}
+
+func (mc *mLRUCache) Has(key string) (bool, error) {
+	_, ok := mc.cache.Get(key)
+	return ok, nil
+}
+
+func (mc *mLRUCache) Get(key string) ([]byte, error) {
+	item, ok := mc.cache.Get(key)
+	if ok {
+		return item.([]byte), nil
+	}
+	return nil, nil
+}
+
+func (mc *mLRUCache) Set(key string, value []byte, ttl time.Duration) error {
+	ok := mc.cache.SetWithTTL(key, value, 0, ttl)
+	if ok {
+		mc.cache.Wait()
+	}
+	return nil
+}
+
+func (mc *mLRUCache) Delete(key string) error {
+	mc.cache.Del(key)
+	mc.cache.Wait()
+	return nil
+}
+
+func (mc *mLRUCache) Flush() error {
+	mc.cache.Clear()
+	mc.cache.Wait()
+	return nil
+}
+
+type mcLRUDriver struct{}
+
+func (mcd *mcLRUDriver) Open(region string, args map[string]string) (cache Cache, err error) {
+	impl, err := ristretto.NewCache(&ristretto.Config{
+		NumCounters: 1e7,
+		MaxCost:     1, // no max cost, all costs are ZERO (for now)
+		BufferItems: 64,
+		Metrics:     isDev,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return &mLRUCache{cache: impl}, nil
+}
+
+func init() {
+	RegisterCache("memoryLRU", &mcLRUDriver{})
+}

--- a/server/storage/cache_memory_lru.go
+++ b/server/storage/cache_memory_lru.go
@@ -12,9 +12,9 @@ type mLRUCache struct {
 	cache *ristretto.Cache
 }
 
-func (mc *mLRUCache) Has(key string) bool {
+func (mc *mLRUCache) Has(key string) (bool, error) {
 	_, ok := mc.cache.Get(key)
-	return ok
+	return ok, nil
 }
 
 func (mc *mLRUCache) Get(key string) ([]byte, error) {

--- a/server/storage/cache_memory_lru.go
+++ b/server/storage/cache_memory_lru.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"errors"
+	"net/url"
 	"time"
 
 	"github.com/dgraph-io/ristretto"
@@ -10,17 +12,22 @@ type mLRUCache struct {
 	cache *ristretto.Cache
 }
 
-func (mc *mLRUCache) Has(key string) (bool, error) {
+func (mc *mLRUCache) Has(key string) bool {
 	_, ok := mc.cache.Get(key)
-	return ok, nil
+	return ok
 }
 
 func (mc *mLRUCache) Get(key string) ([]byte, error) {
-	item, ok := mc.cache.Get(key)
-	if ok {
-		return item.([]byte), nil
+	item, itemFound := mc.cache.Get(key)
+	if itemFound {
+		_, ttlFound := mc.cache.GetTTL(key)
+		if ttlFound {
+			return item.([]byte), nil
+		}
+		mc.cache.Del(key)
+		return nil, ErrExpired
 	}
-	return nil, nil
+	return nil, ErrNotFound
 }
 
 func (mc *mLRUCache) Set(key string, value []byte, ttl time.Duration) error {
@@ -33,24 +40,33 @@ func (mc *mLRUCache) Set(key string, value []byte, ttl time.Duration) error {
 
 func (mc *mLRUCache) Delete(key string) error {
 	mc.cache.Del(key)
-	mc.cache.Wait()
 	return nil
 }
 
 func (mc *mLRUCache) Flush() error {
 	mc.cache.Clear()
-	mc.cache.Wait()
 	return nil
 }
 
 type mcLRUDriver struct{}
 
-func (mcd *mcLRUDriver) Open(region string, args map[string]string) (cache Cache, err error) {
+func (mcd *mcLRUDriver) Open(region string, options url.Values) (cache Cache, err error) {
+	maxCost, err := parseBytesValue(options.Get("maxCost"), 1<<30) // Default maximum cost of cache is 1GB
+	if err != nil {
+		return nil, errors.New("invalid maxCost value")
+	}
 	impl, err := ristretto.NewCache(&ristretto.Config{
 		NumCounters: 1e7,
-		MaxCost:     1, // no max cost, all costs are ZERO (for now)
+		MaxCost:     maxCost,
 		BufferItems: 64,
 		Metrics:     isDev,
+		/**
+		 * Determine cost automatically when cost is zero when set.
+		 * This is skipped entirely if the cost is not zero when set.
+		 */
+		Cost: func(value interface{}) int64 {
+			return int64(len(value.([]byte)))
+		},
 	})
 	if err != nil {
 		return nil, err

--- a/server/storage/db.go
+++ b/server/storage/db.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"net/url"
 	"sync"
 	"time"
 
@@ -11,7 +12,7 @@ import (
 type Store map[string]string
 
 type DB interface {
-	Open(config string) (conn DBConn, err error)
+	Open(config string, options url.Values) (conn DBConn, err error)
 }
 
 type DBConn interface {
@@ -23,11 +24,14 @@ type DBConn interface {
 
 var dbs = sync.Map{}
 
-func OpenDB(dbUrl string) (DBConn, error) {
-	name, config := utils.SplitByFirstByte(dbUrl, ':')
+func OpenDB(url string) (DBConn, error) {
+	name, addr := utils.SplitByFirstByte(url, ':')
 	db, ok := dbs.Load(name)
 	if ok {
-		return db.(DB).Open(config)
+		root, options, err := parseConfigUrl(addr)
+		if err == nil {
+			return db.(DB).Open(root, options)
+		}
 	}
 	return nil, fmt.Errorf("unregistered db '%s'", name)
 }

--- a/server/storage/db_postdb.go
+++ b/server/storage/db_postdb.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"net/url"
 	"time"
 
 	"github.com/postui/postdb"
@@ -9,7 +10,7 @@ import (
 
 type postDB struct{}
 
-func (fs *postDB) Open(path string) (DBConn, error) {
+func (fs *postDB) Open(path string, options url.Values) (DBConn, error) {
 	db, err := postdb.Open(path, 0644)
 	if err != nil {
 		return nil, err

--- a/server/storage/fs_local.go
+++ b/server/storage/fs_local.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"time"
@@ -11,7 +12,7 @@ import (
 
 type localFS struct{}
 
-func (fs *localFS) Open(root string) (FSConn, error) {
+func (fs *localFS) Open(root string, options url.Values) (FSConn, error) {
 	root = utils.CleanPath(root)
 	err := ensureDir(root)
 	if err != nil {

--- a/server/storage/storage.go
+++ b/server/storage/storage.go
@@ -2,8 +2,11 @@ package storage
 
 import (
 	"errors"
+	"net/url"
+	"time"
 
 	logx "github.com/ije/gox/log"
+	"github.com/ije/gox/utils"
 )
 
 var (
@@ -23,6 +26,28 @@ func SetLogger(logger *logx.Logger) {
 
 func SetIsDev(isDevValue bool) {
 	isDev = isDevValue
+}
+
+func parseConfigUrl(configUrl string) (path string, query url.Values, err error) {
+	parsed, err := url.Parse(configUrl)
+	if err != nil {
+		return "", nil, err
+	}
+	return parsed.Path, parsed.Query(), nil
+}
+
+func parseBytesValue(str string, defaultValue int64) (int64, error) {
+	if str != "" {
+		return utils.ParseBytes(str)
+	}
+	return defaultValue, nil
+}
+
+func parseDurationValue(str string, defaultValue time.Duration) (time.Duration, error) {
+	if str != "" {
+		return time.ParseDuration(str)
+	}
+	return defaultValue, nil
 }
 
 func init() {


### PR DESCRIPTION
This doesn't fix the test error that is currently in master yet. Haven't had time to debug.
Just wanted to get this in front of you.

1. Added a cache LRU
2. Added some util functions and make the DB, FS, and Cache interfaces all take the same `options` argument
3. Removed the `err` from the `Has` method
4. Updated the FS LRU implementation to take expiration into account. Didn't think about it, but it would be nice in case TTL is added as an option.