### PR TITLE
🛠️ Fix (storage/fs_local) file path portability bug

### DIFF
--- a/server/storage/fs_local.go
+++ b/server/storage/fs_local.go
@@ -5,15 +5,14 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"time"
-
-	"github.com/ije/gox/utils"
 )
 
 type localFS struct{}
 
 func (fs *localFS) Open(root string, options url.Values) (FS, error) {
-	root = utils.CleanPath(root)
+	root = filepath.Clean(root)
 	err := ensureDir(root)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This PR fixes a Windows file path portability error...

```shell
C> go run main.go --port=8080 --dev
...
2021/09/19 12:17:43 [fatal] init storage(fs,local:C:\Users\Roy\go\src\github.com\alephjs\esm.sh\.dev/storage): CreateFile /C:\Users\Roy\go\src\github.com\alephjs\esm.sh\.dev/storage: The filename, directory name, or volume label syntax is incorrect.
```