### PR TITLE
fix grammar for timeout error

### DIFF
--- a/server/query.go
+++ b/server/query.go
@@ -556,7 +556,7 @@ func query(devMode bool) rex.Handle {
 						return rex.Status(500, err.Error())
 					}
 					if i == n-1 {
-						return rex.Status(http.StatusRequestTimeout, "timeout, we are transforming the types hardly, please try later!")
+						return rex.Status(http.StatusRequestTimeout, "timeout, please try again later!")
 					}
 					time.Sleep(100 * time.Millisecond)
 				}


### PR DESCRIPTION
i also removed the part about the types, since it seems to also say that when importing `.js` files