### PR TITLE
dockerfile fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,14 @@
-FROM golang:1.16
+FROM golang:1.17 AS build
 
-EXPOSE 80 
+RUN apt-get update -y && apt-get install -y xz-utils
 
-WORKDIR /
-
-RUN apt-get update -y && apt-get install -y xz-utils git
-
-RUN git clone https://github.com/alephjs/esm.sh
-
+ADD . /esm.sh
 WORKDIR /esm.sh
 
-RUN go build -o esmd main.go
+RUN --mount=type=cache,target=/go/pkg/mod go build -o esmd main.go
 
-CMD ["esmd", "--etc-dir", "/esm.sh", "--cache", "$CACHE", "--db", "$DB", "--fs", "$FS" "--cdn-domain", "$CDN_DOMAIN"]
+RUN useradd -u 1000 -m esm
+RUN chown -R esm:esm /esm.sh
+USER esm
+
+ENTRYPOINT ["/esm.sh/esmd"]


### PR DESCRIPTION
hi,

since [esm.sh does not work](https://github.com/alephjs/esm.sh/issues/229), i decided to try to run local instance

found few issues in dockerfile:
* update go - apparently current code doesn't work with go 1.16
* add build cache - to avoid downloading go dependencies each time
* make non-root - ugh... they say it's kinda secure way to do it
* thinner wrapping - this is achieved with `ENTRYPOINT` instruction in dockerfile,
  now instead of doing `docker run -e CDN_DOMAIN=localhost -e CACHE=/bla -e DB=/blo ... esm` do `docker run esm --cdn-domain localhost --cache /bla --db /blo ...` (pass through arguments from docker command line)
  this also reduces dockerfile maintenance by making container more generic

btw, on windows docker is the only way to run esm.sh
```sh
# build
docker build . -t esm
# run
docker run -d -v esm:/esm.sh/.esmd -p 8080:8080 esm --cdn-domain localhost:8080 
--port 8080
```
it'll run container and will mount persistent volume, so that after machine restart it won't build everything again.


thanks,
alex